### PR TITLE
Renamed "Combat" gear set to "Current" with auto-save behavior. Inste…

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -162,9 +162,9 @@ local defaults = {
         skillLevels = {},  -- Tracks fishing skill level ups
         poleUsage = {},  -- Tracks fishing pole usage
         gearSets = {
-            fishing = {},  -- Fishing gear set (saved item links)
-            combat = {},   -- Combat gear set (saved item links)
-            currentMode = "combat",  -- Current gear mode: "fishing" or "combat"
+            fishing = {},   -- Fishing gear set (saved item links)
+            current = {},   -- Current gear set (auto-saved before fishing swap)
+            currentMode = "current",  -- Current gear mode: "fishing" or "current"
         },
         backup = {
             enabled = true,  -- Enable automatic backups (enabled by default)
@@ -287,6 +287,17 @@ function CFC:OnInitialize()
                 end
                 self.db.profile.buffUsage[oldName] = nil
             end
+        end
+    end
+
+    -- Migrate gear sets: rename "combat" to "current" (v1.1.8)
+    if self.db.profile.gearSets then
+        if self.db.profile.gearSets.combat and not self.db.profile.gearSets.current then
+            self.db.profile.gearSets.current = self.db.profile.gearSets.combat
+        end
+        self.db.profile.gearSets.combat = nil
+        if self.db.profile.gearSets.currentMode == "combat" then
+            self.db.profile.gearSets.currentMode = "current"
         end
     end
 
@@ -1009,14 +1020,14 @@ function CFC:UpdateCombatSwapMacro()
 
     local btn = self:CreateCombatSwapButton()
 
-    if not self.db or not self.db.profile.gearSets or not self.db.profile.gearSets.combat then
+    if not self.db or not self.db.profile.gearSets or not self.db.profile.gearSets.current then
         if self.debug then
-            print("|cffff0000[CFC Debug]|r No combat gear saved for swap macro")
+            print("|cffff0000[CFC Debug]|r No current gear saved for swap macro")
         end
         return false
     end
 
-    local combatGear = self.db.profile.gearSets.combat
+    local combatGear = self.db.profile.gearSets.current
     local macroLines = {"/stopcasting"}  -- Always stop fishing first
 
     -- Main hand (slot 16)
@@ -1089,9 +1100,9 @@ function CFC:OnCombatStart()
                 end
             else
                 -- Not fishing - try to swap immediately (before combat lockdown kicks in)
-                if self:SwapWeaponsOnly("combat") then
+                if self:SwapWeaponsOnly("current") then
                     self.autoSwappedCombatWeapons = true
-                    CFC:Print("|cff00ff00Classic Fishing Companion:|r Swapped to combat weapons!")
+                    CFC:Print("|cff00ff00Classic Fishing Companion:|r Swapped to current weapons!")
                 else
                     -- Swap failed, show button as fallback
                     self:ShowCombatSwapButton()
@@ -1188,7 +1199,7 @@ function CFC:OnEquipmentChanged(event, slot)
         end
     end
 
-    local currentMode = self.db.profile.gearSets.currentMode or "combat"
+    local currentMode = self.db.profile.gearSets.currentMode or "current"
 
     -- Update mode if it's out of sync
     if isFishingPole and currentMode ~= "fishing" then
@@ -1201,9 +1212,9 @@ function CFC:OnEquipmentChanged(event, slot)
             self:UpdateCombatSwapMacro()
         end
     elseif not isFishingPole and currentMode == "fishing" then
-        self.db.profile.gearSets.currentMode = "combat"
+        self.db.profile.gearSets.currentMode = "current"
         if self.debug then
-            print("|cffff8800[CFC Debug]|r Detected non-fishing weapon equipped - mode set to 'combat'")
+            print("|cffff8800[CFC Debug]|r Detected non-fishing weapon equipped - mode set to 'current'")
         end
     end
 end
@@ -1748,8 +1759,8 @@ function CFC:SaveGearSet(setName)
     if not self.db.profile.gearSets then
         self.db.profile.gearSets = {
             fishing = {},
-            combat = {},
-            currentMode = "combat",
+            current = {},
+            currentMode = "current",
         }
         if self.debug then
             print("|cffff8800[CFC Debug]|r Initialized gearSets database")
@@ -1782,31 +1793,6 @@ function CFC:SaveGearSet(setName)
         print("|cffff8800[CFC Debug]|r Saved " .. itemCount .. " items to " .. setName .. " gear set")
     end
 
-    -- Check if both gear sets are identical
-    local otherSet = (setName == "fishing") and "combat" or "fishing"
-    if self.db.profile.gearSets[otherSet] and next(self.db.profile.gearSets[otherSet]) then
-        local matchingItems = 0
-        local totalItems = 0
-
-        for slotID, itemLink in pairs(gearSet) do
-            totalItems = totalItems + 1
-            local otherItemLink = self.db.profile.gearSets[otherSet][slotID]
-            if otherItemLink then
-                local itemID = tonumber(string.match(itemLink, "item:(%d+)"))
-                local otherItemID = tonumber(string.match(otherItemLink, "item:(%d+)"))
-                if itemID == otherItemID then
-                    matchingItems = matchingItems + 1
-                end
-            end
-        end
-
-        -- If all items match exactly, warn the user
-        if totalItems > 0 and matchingItems == totalItems then
-            CFC:Print("|cffffcc00Classic Fishing Companion:|r |cffff8800WARNING:|r Your fishing and combat gear are identical!")
-            CFC:Print("|cffffcc00Tip:|r Equip different gear for each set to make swapping useful.")
-        end
-    end
-
     return true
 end
 
@@ -1826,7 +1812,7 @@ function CFC:LoadGearSet(setName)
 
     local gearSet = self.db.profile.gearSets[setName]
     if not gearSet or not next(gearSet) then
-        print("|cffff0000Classic Fishing Companion:|r No " .. setName .. " gear set saved. Equip your gear and use /cfc save" .. setName .. " first!")
+        print("|cffff0000Classic Fishing Companion:|r No " .. setName .. " gear set saved!")
         if self.debug then
             print("|cffff0000[CFC Debug]|r Gear set '" .. setName .. "' is empty or doesn't exist")
         end
@@ -2176,33 +2162,35 @@ function CFC:SwapGear()
 
     if not self.db or not self.db.profile or not self.db.profile.gearSets then
         print("|cffff0000Classic Fishing Companion:|r No gear sets configured!")
-        print("|cffffcc00Tip:|r Equip your combat gear, then type |cffff8800/cfc savecombat|r")
-        print("|cffffcc00Then:|r Equip your fishing gear, then type |cffff8800/cfc savefishing|r")
+        print("|cffffcc00Tip:|r Equip your fishing gear, then type |cffff8800/cfc savefishing|r")
         if self.debug then
             print("|cffff0000[CFC Debug]|r Gear sets not configured - database missing")
         end
         return false
     end
 
-    local currentMode = self.db.profile.gearSets.currentMode or "combat"
-    local newMode = (currentMode == "combat") and "fishing" or "combat"
+    local currentMode = self.db.profile.gearSets.currentMode or "current"
+    local newMode = (currentMode == "current") and "fishing" or "current"
 
     if self.debug then
         print("|cffff8800[CFC Debug]|r Current mode: " .. currentMode)
         print("|cffff8800[CFC Debug]|r Target mode: " .. newMode)
     end
 
-    -- Check if both gear sets exist
-    local hasCombat = self.db.profile.gearSets.combat and next(self.db.profile.gearSets.combat)
+    -- Check if fishing gear set exists
     local hasFishing = self.db.profile.gearSets.fishing and next(self.db.profile.gearSets.fishing)
 
     if self.debug then
-        print("|cffff8800[CFC Debug]|r Has combat gear: " .. tostring(hasCombat))
         print("|cffff8800[CFC Debug]|r Has fishing gear: " .. tostring(hasFishing))
     end
 
-    -- When swapping to fishing, verify the fishing pole is available
+    -- When swapping to fishing, auto-save current gear and verify the fishing pole is available
     if newMode == "fishing" and hasFishing then
+        -- Auto-save current equipment before swapping to fishing
+        if self.debug then
+            print("|cffff8800[CFC Debug]|r Auto-saving current gear before fishing swap...")
+        end
+        self:SaveGearSet("current")
         local fishingSet = self.db.profile.gearSets.fishing
         local poleLink = fishingSet[16] -- Main Hand slot
         if poleLink then
@@ -2236,7 +2224,8 @@ function CFC:SwapGear()
     end
 
     if self:LoadGearSet(newMode) then
-        CFC:Print("|cff00ff00Classic Fishing Companion:|r Swapped to " .. newMode .. " gear!")
+        local displayMode = (newMode == "current") and "current" or "fishing"
+        CFC:Print("|cff00ff00Classic Fishing Companion:|r Swapped to " .. displayMode .. " gear!")
         if self.debug then
             print("|cff00ff00[CFC Debug]|r ===== GEAR SWAP COMPLETE =====")
         end
@@ -2588,25 +2577,21 @@ function CFC:HasGearSets()
     end
 
     local fishing = self.db.profile.gearSets.fishing
-    local combat = self.db.profile.gearSets.combat
-
     local hasFishing = fishing and next(fishing)
-    local hasCombat = combat and next(combat)
-    local hasGearSets = hasFishing and hasCombat
 
-    return hasGearSets
+    return hasFishing
 end
 
 -- Get current gear mode
 function CFC:GetCurrentGearMode()
     if not self.db or not self.db.profile or not self.db.profile.gearSets then
         if self.debug then
-            print("|cffff8800[CFC Debug]|r GetCurrentGearMode: No database, defaulting to 'combat'")
+            print("|cffff8800[CFC Debug]|r GetCurrentGearMode: No database, defaulting to 'current'")
         end
-        return "combat"
+        return "current"
     end
 
-    local mode = self.db.profile.gearSets.currentMode or "combat"
+    local mode = self.db.profile.gearSets.currentMode or "current"
     return mode
 end
 
@@ -2993,11 +2978,9 @@ SlashCmdList["CFC"] = function(msg)
         CFC:SaveGearSet("fishing")
         CFC:Print("|cff00ff00Classic Fishing Companion:|r Fishing gear set saved!")
     elseif msg == "savecombat" then
-        if CFC.debug then
-            print("|cffff8800[CFC Debug]|r Slash command: savecombat")
-        end
-        CFC:SaveGearSet("combat")
-        CFC:Print("|cff00ff00Classic Fishing Companion:|r Combat gear set saved!")
+        -- Legacy command - inform user about the change
+        CFC:Print("|cffffcc00Classic Fishing Companion:|r The savecombat command has been removed.")
+        CFC:Print("|cffffcc00Info:|r Your current gear is now auto-saved when you swap to fishing gear.")
     elseif msg == "swap" or msg == "gear" then
         if CFC.debug then
             print("|cffff8800[CFC Debug]|r Slash command: swap/gear")
@@ -3038,14 +3021,13 @@ SlashCmdList["CFC"] = function(msg)
             if CFC.db.profile.settings.autoSwapOnHUD then
                 local gearSets = CFC.db.profile.gearSets
                 local hasFishingGear = gearSets and gearSets.fishing and next(gearSets.fishing)
-                local hasCombatGear = gearSets and gearSets.combat and next(gearSets.combat)
 
-                if hasFishingGear and hasCombatGear then
+                if hasFishingGear then
                     local hudCurrentlyShown = CFC.db.profile.hud.show
-                    local currentMode = gearSets.currentMode or "combat"
+                    local currentMode = gearSets.currentMode or "current"
 
                     if hudCurrentlyShown then
-                        if currentMode ~= "combat" and CFC.SwapGear then
+                        if currentMode ~= "current" and CFC.SwapGear then
                             if CFC:SwapGear() == false then
                                 swapBlocked = true
                             end
@@ -3058,7 +3040,7 @@ SlashCmdList["CFC"] = function(msg)
                         end
                     end
                 else
-                    CFC:Print("|cffff8800[CFC]|r Auto-swap enabled but gear sets not configured. Please save both fishing and combat gear sets in the Gear Sets tab.")
+                    CFC:Print("|cffff8800[CFC]|r Auto-swap enabled but fishing gear set not configured. Please save your fishing gear set in the Gear Sets tab.")
                 end
             end
             if not swapBlocked then

--- a/HUD.lua
+++ b/HUD.lua
@@ -237,11 +237,11 @@ function CFC:InitializeHUD()
             return
         end
 
-        -- Check if user has gear sets configured and is in combat mode
+        -- Check if user has gear sets configured and is in current mode
         if CFC:HasGearSets() then
             local currentMode = CFC:GetCurrentGearMode()
-            if currentMode == "combat" then
-                print("|cffff0000Classic Fishing Companion:|r You're in combat gear! Swap to fishing gear first.")
+            if currentMode == "current" then
+                print("|cffff0000Classic Fishing Companion:|r You're not in fishing gear! Swap to fishing gear first.")
                 print("|cff00ff00Tip:|r Click the 'Swap to' button or use /cfc swap")
             end
         end
@@ -294,17 +294,16 @@ function CFC:InitializeHUD()
 
         if CFC:HasGearSets() then
             local currentMode = CFC:GetCurrentGearMode()
-            local targetMode = (currentMode == "combat") and "fishing" or "combat"
+            local targetMode = (currentMode == "current") and "fishing" or "current"
 
             GameTooltip:SetText("Swap Gear", 1, 1, 1)
             GameTooltip:AddLine("Current: " .. currentMode, 0.8, 0.8, 0.8)
             GameTooltip:AddLine("Click to switch to " .. targetMode .. " gear", 0.6, 1, 0.6)
         else
             GameTooltip:SetText("Gear Swap Not Configured", 1, 0.5, 0.5)
-            GameTooltip:AddLine("1. Equip combat gear", 1, 1, 1)
-            GameTooltip:AddLine("2. Type: /cfc savecombat", 0.8, 0.8, 0.8)
-            GameTooltip:AddLine("3. Equip fishing gear", 1, 1, 1)
-            GameTooltip:AddLine("4. Type: /cfc savefishing", 0.8, 0.8, 0.8)
+            GameTooltip:AddLine("1. Equip fishing gear", 1, 1, 1)
+            GameTooltip:AddLine("2. Type: /cfc savefishing", 0.8, 0.8, 0.8)
+            GameTooltip:AddLine("Current gear auto-saves on swap", 0.6, 1, 0.6)
         end
 
         GameTooltip:Show()
@@ -506,7 +505,7 @@ function HUDModule:Update()
         local currentMode = CFC:GetCurrentGearMode()
         if CFC:HasGearSets() then
             -- Show icon of what we're swapping TO (opposite of current mode)
-            local targetIcon = (currentMode == "combat") and "|TInterface\\Icons\\Trade_Fishing:16|t" or "|TInterface\\Icons\\INV_Sword_04:16|t"
+            local targetIcon = (currentMode == "current") and "|TInterface\\Icons\\Trade_Fishing:16|t" or "|TInterface\\Icons\\INV_Sword_04:16|t"
             hudFrame.gearSwapButton:SetText("Swap to " .. targetIcon)
         else
             hudFrame.gearSwapButton:SetText("|TInterface\\DialogFrame\\UI-Dialog-Icon-AlertNew:16|t Setup")

--- a/Minimap.lua
+++ b/Minimap.lua
@@ -58,20 +58,19 @@ function CFC:InitializeMinimap()
                 local swapBlocked = false
                 -- Check if auto-swap is enabled
                 if CFC.db and CFC.db.profile and CFC.db.profile.settings and CFC.db.profile.settings.autoSwapOnHUD then
-                    -- Check if gear sets are configured
+                    -- Check if fishing gear set is configured
                     local gearSets = CFC.db.profile.gearSets
                     local hasFishingGear = gearSets and gearSets.fishing and next(gearSets.fishing)
-                    local hasCombatGear = gearSets and gearSets.combat and next(gearSets.combat)
 
-                    if not hasFishingGear or not hasCombatGear then
-                        -- Warn if gear sets not configured
-                        CFC:Print("|cffff8800[CFC]|r Auto-swap enabled but gear sets not configured. Please save both fishing and combat gear sets in the Gear Sets tab.")
+                    if not hasFishingGear then
+                        -- Warn if fishing gear set not configured
+                        CFC:Print("|cffff8800[CFC]|r Auto-swap enabled but fishing gear set not configured. Please save your fishing gear set in the Gear Sets tab.")
                     else
                         local hudCurrentlyShown = CFC.db.profile.hud.show
-                        local currentMode = gearSets.currentMode or "combat"
+                        local currentMode = gearSets.currentMode or "current"
 
                         if hudCurrentlyShown then
-                            if currentMode ~= "combat" and CFC.SwapGear then
+                            if currentMode ~= "current" and CFC.SwapGear then
                                 if CFC:SwapGear() == false then
                                     swapBlocked = true
                                 end

--- a/TBC/HUD.lua
+++ b/TBC/HUD.lua
@@ -314,17 +314,16 @@ function CFC:InitializeHUD()
 
         if CFC:HasGearSets() then
             local currentMode = CFC:GetCurrentGearMode()
-            local targetMode = (currentMode == "combat") and "fishing" or "combat"
+            local targetMode = (currentMode == "current") and "fishing" or "current"
 
             GameTooltip:SetText("Swap Gear", 1, 1, 1)
             GameTooltip:AddLine("Current: " .. currentMode, 0.8, 0.8, 0.8)
             GameTooltip:AddLine("Click to switch to " .. targetMode .. " gear", 0.6, 1, 0.6)
         else
             GameTooltip:SetText("Gear Swap Not Configured", 1, 0.5, 0.5)
-            GameTooltip:AddLine("1. Equip combat gear", 1, 1, 1)
-            GameTooltip:AddLine("2. Type: /cfc savecombat", 0.8, 0.8, 0.8)
-            GameTooltip:AddLine("3. Equip fishing gear", 1, 1, 1)
-            GameTooltip:AddLine("4. Type: /cfc savefishing", 0.8, 0.8, 0.8)
+            GameTooltip:AddLine("1. Equip fishing gear", 1, 1, 1)
+            GameTooltip:AddLine("2. Type: /cfc savefishing", 0.8, 0.8, 0.8)
+            GameTooltip:AddLine("Current gear auto-saves on swap", 0.6, 1, 0.6)
         end
 
         GameTooltip:Show()
@@ -542,7 +541,7 @@ function HUDModule:Update()
         local currentMode = CFC:GetCurrentGearMode()
         if CFC:HasGearSets() then
             -- Show icon of what we're swapping TO (opposite of current mode)
-            local targetIcon = (currentMode == "combat") and "|TInterface\\Icons\\Trade_Fishing:16|t" or "|TInterface\\Icons\\INV_Sword_04:16|t"
+            local targetIcon = (currentMode == "current") and "|TInterface\\Icons\\Trade_Fishing:16|t" or "|TInterface\\Icons\\INV_Sword_04:16|t"
             hudFrame.gearSwapButton:SetText("Swap to " .. targetIcon)
         else
             hudFrame.gearSwapButton:SetText("|TInterface\\DialogFrame\\UI-Dialog-Icon-AlertNew:16|t Setup")

--- a/TBC/UI.lua
+++ b/TBC/UI.lua
@@ -1686,7 +1686,6 @@ function UI:UpdateStats()
         table.sort(poleList, function(a, b) return a.count > b.count end)
 
         if #poleList > 0 then
-            bottomText = bottomText .. "\n"
             for _, pole in ipairs(poleList) do
                 bottomText = bottomText .. pole.name .. ": |cff00ff00" .. pole.count .. " catches|r\n"
             end
@@ -1698,7 +1697,7 @@ function UI:UpdateStats()
     end
 
     -- Fishing Lures Used
-    bottomText = bottomText .. "\n\n|cffffd700Fishing Lures Used:|r\n"
+    bottomText = bottomText .. "\n|cffffd700Fishing Lures Used:|r\n"
     if CFC.db.profile.buffUsage then
         local buffList = {}
         for buffName, data in pairs(CFC.db.profile.buffUsage) do
@@ -1709,7 +1708,6 @@ function UI:UpdateStats()
         table.sort(buffList, function(a, b) return a.count > b.count end)
 
         if #buffList > 0 then
-            bottomText = bottomText .. "\n"
             for _, buff in ipairs(buffList) do
                 bottomText = bottomText .. buff.name .. ": |cff00ff00" .. buff.count .. " times|r\n"
             end
@@ -1721,7 +1719,7 @@ function UI:UpdateStats()
     end
 
     -- Top fish
-    bottomText = bottomText .. "\n\n|cffffd700Top 10 Most Caught Fish:|r\n\n"
+    bottomText = bottomText .. "\n|cffffd700Top 10 Most Caught Fish:|r\n"
     local fishList = CFC.Database:GetFishList()
 
     if #fishList > 0 then
@@ -1735,7 +1733,7 @@ function UI:UpdateStats()
     end
 
     -- Top zones
-    bottomText = bottomText .. "\n\n|cffffd700Fishing Zones:|r\n\n"
+    bottomText = bottomText .. "\n|cffffd700Fishing Zones:|r\n"
     local zones = CFC.Database:GetZoneList()
 
     if #zones > 0 then
@@ -1783,15 +1781,15 @@ function UI:CreateGearSetsTab()
     }
     frame.slotOrder = slotOrder
     frame.slotNames = slotNames
-    frame.activeSet = "combat"
+    frame.activeSet = "current"
 
     -- Toggle buttons
     frame.combatToggle = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     frame.combatToggle:SetSize(100, 22)
     frame.combatToggle:SetPoint("TOPLEFT", frame.desc, "BOTTOMLEFT", 0, -8)
-    frame.combatToggle:SetText("|cffff8000Combat|r")
+    frame.combatToggle:SetText("|cffff8000Current|r")
     frame.combatToggle:SetScript("OnClick", function()
-        frame.activeSet = "combat"
+        frame.activeSet = "current"
         UI:UpdateGearSetsTab()
     end)
 
@@ -1804,17 +1802,15 @@ function UI:CreateGearSetsTab()
         UI:UpdateGearSetsTab()
     end)
 
-    -- Save button
+    -- Save button (only for fishing set)
     frame.saveBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     frame.saveBtn:SetSize(120, 22)
     frame.saveBtn:SetPoint("LEFT", frame.fishingToggle, "RIGHT", 4, 0)
     frame.saveBtn:SetText("Save Set")
     frame.saveBtn:SetScript("OnClick", function()
-        local setName = frame.activeSet
-        local label = (setName == "combat") and "Combat Gear" or "Fishing Gear"
-        CFC:SaveGearSet(setName)
+        CFC:SaveGearSet("fishing")
         UI:UpdateGearSetsTab()
-        CFC:Print("|cff00ff00Classic Fishing Companion:|r " .. label .. " saved!")
+        CFC:Print("|cff00ff00Classic Fishing Companion:|r Fishing Gear saved!")
     end)
 
     -- Swap Gear Button
@@ -1890,12 +1886,12 @@ function UI:UpdateGearSetsTab()
         return
     end
 
-    local activeSet = frame.activeSet or "combat"
+    local activeSet = frame.activeSet or "current"
     local gearData = CFC.db.profile.gearSets[activeSet] or {}
     local isEmpty = not next(gearData)
 
     -- Update toggle highlights
-    if activeSet == "combat" then
+    if activeSet == "current" then
         frame.combatToggle:LockHighlight()
         frame.fishingToggle:UnlockHighlight()
     else
@@ -1903,9 +1899,16 @@ function UI:UpdateGearSetsTab()
         frame.fishingToggle:LockHighlight()
     end
 
-    -- Update save button text
-    local setLabel = (activeSet == "combat") and "Combat Gear" or "Fishing Gear"
-    frame.saveBtn:SetText("Save " .. setLabel)
+    -- Update save button and description based on active set
+    if activeSet == "current" then
+        frame.saveBtn:Hide()
+        frame.desc:SetText("Your current gear is |cff00ff00auto-saved|r before each fishing swap. |cff00ff00Green|r = available, |cffff0000Red|r = missing from bags.")
+    else
+        frame.saveBtn:SetText("Save Fishing Gear")
+        frame.saveBtn:Enable()
+        frame.saveBtn:Show()
+        frame.desc:SetText("Equip your fishing gear, then click Save. |cff00ff00Green|r = available, |cffff0000Red|r = missing from bags.")
+    end
 
     -- Hide all rows
     for i = 1, #frame.rows do
@@ -1916,7 +1919,11 @@ function UI:UpdateGearSetsTab()
     end
 
     if isEmpty then
-        frame.statusText:SetText("|cffff0000No gear saved|r - Equip your " .. setLabel:lower() .. ", then click Save.")
+        if activeSet == "current" then
+            frame.statusText:SetText("|cffff0000No gear saved yet|r - Gear will be auto-saved when you swap to fishing.")
+        else
+            frame.statusText:SetText("|cffff0000No gear saved|r - Equip your fishing gear, then click Save.")
+        end
     else
         -- Validate the active set
         local validation = CFC:ValidateGearSet(activeSet)
@@ -2001,22 +2008,12 @@ function UI:CreateLuresTab()
     frame.clearBtn:SetScript("OnClick", function()
         CFC.db.profile.selectedLure = nil
         UI:UpdateLuresTab()
-        -- Update HUD lure button
-        if CFC.HUD and CFC.HUD.UpdateLureButton then
-            CFC.HUD:UpdateLureButton()
+
+        -- Update the Apply Lure button macro on the HUD
+        if CFC.hudFrame and CFC.hudFrame.UpdateApplyLureMacro then
+            CFC.hudFrame.UpdateApplyLureMacro()
         end
-        CFC:Print("|cff00ff00Classic Fishing Companion:|r Lure selection cleared.")
     end)
-
-    -- Create scroll frame for lure buttons
-    frame.scrollFrame = CreateFrame("ScrollFrame", nil, frame, "UIPanelScrollFrameTemplate")
-    frame.scrollFrame:SetPoint("TOPLEFT", frame.selectedLure, "BOTTOMLEFT", 0, -20)
-    frame.scrollFrame:SetSize(270, 200)
-
-    -- Create content frame for scroll (holds the buttons)
-    frame.scrollChild = CreateFrame("Frame", nil, frame.scrollFrame)
-    frame.scrollChild:SetSize(250, 300)
-    frame.scrollFrame:SetScrollChild(frame.scrollChild)
 
     -- Lure selection buttons
     local lureData = {
@@ -2026,14 +2023,13 @@ function UI:CreateLuresTab()
         { name = "Bright Baubles", id = 6532, bonus = 75, icon = "INV_Misc_Gem_Variety_02" },
         { name = "Flesh Eating Worm", id = 7307, bonus = 75, icon = "INV_Misc_MonsterTail_03" },
         { name = "Aquadynamic Fish Attractor", id = 6533, bonus = 100, icon = "INV_Misc_Food_26" },
-        { name = "Sharpened Fish Hook", id = 34861, bonus = 100, icon = "INV_Misc_Hook_01" },
     }
 
-    local yOffset = -10
+    local yOffset = -120
     for i, lure in ipairs(lureData) do
-        local btn = CreateFrame("Button", nil, frame.scrollChild, "UIPanelButtonTemplate")
+        local btn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
         btn:SetSize(250, 30)
-        btn:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", 0, yOffset)
+        btn:SetPoint("TOPLEFT", frame, "TOPLEFT", 20, yOffset)
 
         -- Add faction icon if specified
         local buttonText = "|TInterface\\Icons\\" .. lure.icon .. ":20|t " .. lure.name .. " (+" .. lure.bonus .. ")"
@@ -2045,11 +2041,11 @@ function UI:CreateLuresTab()
         btn:SetScript("OnClick", function()
             CFC.db.profile.selectedLure = lure.id
             UI:UpdateLuresTab()
-            -- Update HUD lure button
-            if CFC.HUD and CFC.HUD.UpdateLureButton then
-                CFC.HUD:UpdateLureButton()
+
+            -- Update the Apply Lure button macro on the HUD
+            if CFC.hudFrame and CFC.hudFrame.UpdateApplyLureMacro then
+                CFC.hudFrame.UpdateApplyLureMacro()
             end
-            CFC:Print("|cff00ff00Classic Fishing Companion:|r Selected " .. lure.name)
         end)
 
         yOffset = yOffset - 40
@@ -2068,34 +2064,6 @@ function UI:CreateLuresTab()
     frame.easyCastHint:SetPoint("TOPLEFT", frame.easyCastStatus, "BOTTOMLEFT", 0, -5)
     frame.easyCastHint:SetWidth(220)
     frame.easyCastHint:SetJustifyH("LEFT")
-
-    -- Captain Rumsey's Lager section
-    frame.rumseyHeader = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    frame.rumseyHeader:SetPoint("TOPLEFT", frame.easyCastHint, "BOTTOMLEFT", 0, -25)
-    frame.rumseyHeader:SetText("Captain Rumsey's Lager:")
-    frame.rumseyHeader:SetTextColor(0, 0.8, 1)
-
-    frame.autoRumseyCheck = CreateFrame("CheckButton", "CFCAutoRumseyCheck", frame, "UICheckButtonTemplate")
-    frame.autoRumseyCheck:SetPoint("TOPLEFT", frame.rumseyHeader, "BOTTOMLEFT", 0, -8)
-    frame.autoRumseyCheck.text = frame.autoRumseyCheck:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    frame.autoRumseyCheck.text:SetPoint("LEFT", frame.autoRumseyCheck, "RIGHT", 5, 0)
-    frame.autoRumseyCheck.text:SetText("Auto-Drink with Easy Cast")
-
-    frame.autoRumseyCheck:SetScript("OnClick", function(self)
-        CFC.db.profile.settings.autoRumsey = self:GetChecked()
-        if CFC.db.profile.settings.autoRumsey then
-            CFC:Print(CFC.COLORS.SUCCESS .. "Classic Fishing Companion:" .. CFC.COLORS.RESET .. " Auto-Drink Rumsey's " .. CFC.COLORS.SUCCESS .. "enabled|r")
-        else
-            CFC:Print(CFC.COLORS.SUCCESS .. "Classic Fishing Companion:" .. CFC.COLORS.RESET .. " Auto-Drink Rumsey's " .. CFC.COLORS.ERROR .. "disabled|r")
-        end
-    end)
-
-    frame.rumseyDesc = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    frame.rumseyDesc:SetPoint("TOPLEFT", frame.autoRumseyCheck, "BOTTOMLEFT", 20, -5)
-    frame.rumseyDesc:SetWidth(220)
-    frame.rumseyDesc:SetJustifyH("LEFT")
-    frame.rumseyDesc:SetTextColor(0.7, 0.7, 0.7)
-    frame.rumseyDesc:SetText("Automatically drink Captain Rumsey's Lager (+10 fishing) before casting when Easy Cast fires.")
 
     -- Store reference
     mainFrame.luresFrame = frame
@@ -2132,11 +2100,6 @@ function UI:UpdateLuresTab()
         frame.easyCastStatus:SetText("Disabled")
         frame.easyCastStatus:SetTextColor(1, 0, 0)  -- Red
         frame.easyCastHint:SetText("Go to Settings tab to enable Easy Cast.")
-    end
-
-    -- Update Rumsey checkbox
-    if frame.autoRumseyCheck then
-        frame.autoRumseyCheck:SetChecked(CFC.db.profile.settings.autoRumsey or false)
     end
 end
 
@@ -2779,7 +2742,7 @@ function UI:CreateSettingsTab()
     frame.maxSkillCheck:SetPoint("TOPLEFT", frame.announceSkillUpsDesc, "BOTTOMLEFT", -25, -30)
     frame.maxSkillCheck.text = frame.maxSkillCheck:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     frame.maxSkillCheck.text:SetPoint("LEFT", frame.maxSkillCheck, "RIGHT", 5, 0)
-    frame.maxSkillCheck.text:SetText("Announce Max Skill (375)")
+    frame.maxSkillCheck.text:SetText("Announce Max Skill (300)")
 
     frame.maxSkillCheck:SetScript("OnClick", function(self)
         local enabled = self:GetChecked()
@@ -3077,7 +3040,7 @@ function UI:CreateSettingsTab()
     frame.autoSwapDesc:SetJustifyH("LEFT")
     frame.autoSwapDesc:SetWidth(500)
     frame.autoSwapDesc:SetTextColor(0.7, 0.7, 0.7)
-    frame.autoSwapDesc:SetText("Automatically swap to fishing gear when showing HUD (right-click minimap), and swap to combat gear when hiding HUD. Requires gear sets to be saved.")
+    frame.autoSwapDesc:SetText("Automatically swap to fishing gear when showing HUD (right-click minimap), and swap to current gear when hiding HUD. Requires fishing gear set to be saved.")
 
     -- HUD Scale Slider
     frame.hudScaleLabel = frame.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -3172,28 +3135,9 @@ function UI:CreateSettingsTab()
         end
     end)
 
-    -- Show Rumsey Icon Checkbox
-    frame.showRumseyButtonCheck = CreateFrame("CheckButton", "CFCShowRumseyButtonCheck", frame.scrollChild, "UICheckButtonTemplate")
-    frame.showRumseyButtonCheck:SetPoint("TOPLEFT", frame.showSwapButtonCheck, "BOTTOMLEFT", 0, -5)
-    frame.showRumseyButtonCheck.text = frame.showRumseyButtonCheck:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    frame.showRumseyButtonCheck.text:SetPoint("LEFT", frame.showRumseyButtonCheck, "RIGHT", 5, 0)
-    frame.showRumseyButtonCheck.text:SetText("Show Rumsey Icon on HUD")
-
-    frame.showRumseyButtonCheck:SetScript("OnClick", function(self)
-        CFC.db.profile.settings.hudShowRumseyButton = self:GetChecked()
-        if CFC.HUD and CFC.HUD.UpdateRumseyIcon then
-            CFC.HUD:UpdateRumseyIcon()
-        end
-        if CFC.db.profile.settings.hudShowRumseyButton then
-            CFC:Print("|cff00ff00Classic Fishing Companion:|r HUD Rumsey icon |cff00ff00shown|r")
-        else
-            CFC:Print("|cff00ff00Classic Fishing Companion:|r HUD Rumsey icon |cffff0000hidden|r")
-        end
-    end)
-
     -- Button visibility description
     frame.hudButtonDesc = frame.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    frame.hudButtonDesc:SetPoint("TOPLEFT", frame.showRumseyButtonCheck, "BOTTOMLEFT", 25, -5)
+    frame.hudButtonDesc:SetPoint("TOPLEFT", frame.showSwapButtonCheck, "BOTTOMLEFT", 25, -5)
     frame.hudButtonDesc:SetJustifyH("LEFT")
     frame.hudButtonDesc:SetWidth(500)
     frame.hudButtonDesc:SetTextColor(0.7, 0.7, 0.7)
@@ -3250,7 +3194,7 @@ function UI:CreateSettingsTab()
     frame.autoSwapCombatDesc:SetJustifyH("LEFT")
     frame.autoSwapCombatDesc:SetWidth(500)
     frame.autoSwapCombatDesc:SetTextColor(0.7, 0.7, 0.7)
-    frame.autoSwapCombatDesc:SetText("When combat starts with fishing pole equipped: if not casting, auto-swaps to combat weapons. If actively casting, a button appears to click to swap. When combat ends, auto-swaps back to fishing pole. Requires combat gear set to be saved.")
+    frame.autoSwapCombatDesc:SetText("When combat starts with fishing pole equipped: if not casting, auto-swaps to your current weapons. If actively casting, a button appears to click to swap. When combat ends, auto-swaps back to fishing pole. Current gear is auto-saved before each fishing swap.")
 
     -- =============================================
     -- ADVANCED SECTION
@@ -3505,7 +3449,6 @@ function UI:UpdateSettings()
     -- Update button visibility checkboxes
     frame.showLureButtonCheck:SetChecked(CFC.db.profile.settings.hudShowLureButton)
     frame.showSwapButtonCheck:SetChecked(CFC.db.profile.settings.hudShowSwapButton)
-    frame.showRumseyButtonCheck:SetChecked(CFC.db.profile.settings.hudShowRumseyButton)
 
     -- Update auto-swap checkbox
     frame.autoSwapCheck:SetChecked(CFC.db.profile.settings.autoSwapOnHUD)
@@ -3685,11 +3628,7 @@ StaticPopupDialogs["CFC_PERCHAR_ENABLE"] = {
     end,
     OnCancel = function(self)
         -- Show the "start fresh" confirmation
-        local totalCatches = 0
-        if ClassicFishingCompanionDB and ClassicFishingCompanionDB.profile and ClassicFishingCompanionDB.profile.statistics then
-            totalCatches = ClassicFishingCompanionDB.profile.statistics.totalCatches or 0
-        end
-        StaticPopup_Show("CFC_PERCHAR_ENABLE_FRESH", totalCatches)
+        StaticPopup_Show("CFC_PERCHAR_ENABLE_FRESH")
     end,
     OnHide = function(self)
         -- If dialog was hidden without choosing, revert checkbox
@@ -3782,9 +3721,6 @@ local whatsNewContent = {
     },
     ["1.1.6"] = {
         features = {
-            "Captain Rumsey's Lager auto-drink with Easy Cast (TBC)",
-            "Rumsey toggle icon on HUD, click to enable/disable",
-            "Rumsey +10 fishing bonus shows on the Skill line",
             "Easy Cast now allows recasting while your line is already out",
         },
         tip = "Thank you for 10,000 downloads! Your support means the world. Classic Fishing Companion started as a small passion project and thanks to you, it's grown into something special.\n\nTight lines and happy fishing!\n- Relyk"
@@ -3926,7 +3862,7 @@ local whatsNewContent = {
             "When combat ends, auto-swaps back to your fishing pole",
         },
         fixes = {},
-        tip = "TIP: Enable 'Auto-Swap Combat Weapons' in Settings!\nSave your combat gear first with /cfc savecombat, then fish safely knowing you can defend yourself."
+        tip = "TIP: Enable 'Auto-Swap Combat Weapons' in Settings!\nYour current gear is auto-saved before each fishing swap, so you can fish safely knowing you can defend yourself."
     },
     ["1.0.12"] = {
         features = {
@@ -3965,7 +3901,7 @@ local whatsNewContent = {
             "New setting in Settings tab to enable/disable",
         },
         fixes = {},
-        tip = "TIP: Enable 'Auto-Swap Gear on HUD Toggle' in Settings for one-click fishing setup!\nMake sure to save both your fishing and combat gear sets first."
+        tip = "TIP: Enable 'Auto-Swap Gear on HUD Toggle' in Settings for one-click fishing setup!\nMake sure to save your fishing gear set first. Your current gear is auto-saved on swap."
     },
     ["1.0.9"] = {
         features = {
@@ -4099,15 +4035,15 @@ StaticPopupDialogs["CFC_WHATS_NEW"] = {
 }
 
 StaticPopupDialogs["CFC_CLEAR_GEAR_SETS"] = {
-    text = "Are you sure you want to clear ALL gear sets?\n\nThis will delete:\n• Combat gear set\n• Fishing gear set\n\nYou will need to reconfigure your gear sets after this.\n\nThis action CANNOT be undone!",
+    text = "Are you sure you want to clear ALL gear sets?\n\nThis will delete:\n• Current gear set (auto-saved)\n• Fishing gear set\n\nYou will need to reconfigure your gear sets after this.\n\nThis action CANNOT be undone!",
     button1 = "Yes, Clear Gear Sets",
     button2 = "Cancel",
     OnAccept = function()
         if CFC.db and CFC.db.profile and CFC.db.profile.gearSets then
             -- Clear both gear sets
-            CFC.db.profile.gearSets.combat = {}
+            CFC.db.profile.gearSets.current = {}
             CFC.db.profile.gearSets.fishing = {}
-            CFC.db.profile.gearSets.currentMode = "combat"
+            CFC.db.profile.gearSets.currentMode = "current"
 
             CFC:Print("|cff00ff00Classic Fishing Companion:|r All gear sets have been cleared.")
 

--- a/UI.lua
+++ b/UI.lua
@@ -1781,15 +1781,15 @@ function UI:CreateGearSetsTab()
     }
     frame.slotOrder = slotOrder
     frame.slotNames = slotNames
-    frame.activeSet = "combat"
+    frame.activeSet = "current"
 
     -- Toggle buttons
     frame.combatToggle = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     frame.combatToggle:SetSize(100, 22)
     frame.combatToggle:SetPoint("TOPLEFT", frame.desc, "BOTTOMLEFT", 0, -8)
-    frame.combatToggle:SetText("|cffff8000Combat|r")
+    frame.combatToggle:SetText("|cffff8000Current|r")
     frame.combatToggle:SetScript("OnClick", function()
-        frame.activeSet = "combat"
+        frame.activeSet = "current"
         UI:UpdateGearSetsTab()
     end)
 
@@ -1802,17 +1802,15 @@ function UI:CreateGearSetsTab()
         UI:UpdateGearSetsTab()
     end)
 
-    -- Save button
+    -- Save button (only for fishing set)
     frame.saveBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
     frame.saveBtn:SetSize(120, 22)
     frame.saveBtn:SetPoint("LEFT", frame.fishingToggle, "RIGHT", 4, 0)
     frame.saveBtn:SetText("Save Set")
     frame.saveBtn:SetScript("OnClick", function()
-        local setName = frame.activeSet
-        local label = (setName == "combat") and "Combat Gear" or "Fishing Gear"
-        CFC:SaveGearSet(setName)
+        CFC:SaveGearSet("fishing")
         UI:UpdateGearSetsTab()
-        CFC:Print("|cff00ff00Classic Fishing Companion:|r " .. label .. " saved!")
+        CFC:Print("|cff00ff00Classic Fishing Companion:|r Fishing Gear saved!")
     end)
 
     -- Swap Gear Button
@@ -1888,12 +1886,12 @@ function UI:UpdateGearSetsTab()
         return
     end
 
-    local activeSet = frame.activeSet or "combat"
+    local activeSet = frame.activeSet or "current"
     local gearData = CFC.db.profile.gearSets[activeSet] or {}
     local isEmpty = not next(gearData)
 
     -- Update toggle highlights
-    if activeSet == "combat" then
+    if activeSet == "current" then
         frame.combatToggle:LockHighlight()
         frame.fishingToggle:UnlockHighlight()
     else
@@ -1901,9 +1899,16 @@ function UI:UpdateGearSetsTab()
         frame.fishingToggle:LockHighlight()
     end
 
-    -- Update save button text
-    local setLabel = (activeSet == "combat") and "Combat Gear" or "Fishing Gear"
-    frame.saveBtn:SetText("Save " .. setLabel)
+    -- Update save button and description based on active set
+    if activeSet == "current" then
+        frame.saveBtn:Hide()
+        frame.desc:SetText("Your current gear is |cff00ff00auto-saved|r before each fishing swap. |cff00ff00Green|r = available, |cffff0000Red|r = missing from bags.")
+    else
+        frame.saveBtn:SetText("Save Fishing Gear")
+        frame.saveBtn:Enable()
+        frame.saveBtn:Show()
+        frame.desc:SetText("Equip your fishing gear, then click Save. |cff00ff00Green|r = available, |cffff0000Red|r = missing from bags.")
+    end
 
     -- Hide all rows
     for i = 1, #frame.rows do
@@ -1914,7 +1919,11 @@ function UI:UpdateGearSetsTab()
     end
 
     if isEmpty then
-        frame.statusText:SetText("|cffff0000No gear saved|r - Equip your " .. setLabel:lower() .. ", then click Save.")
+        if activeSet == "current" then
+            frame.statusText:SetText("|cffff0000No gear saved yet|r - Gear will be auto-saved when you swap to fishing.")
+        else
+            frame.statusText:SetText("|cffff0000No gear saved|r - Equip your fishing gear, then click Save.")
+        end
     else
         -- Validate the active set
         local validation = CFC:ValidateGearSet(activeSet)
@@ -3031,7 +3040,7 @@ function UI:CreateSettingsTab()
     frame.autoSwapDesc:SetJustifyH("LEFT")
     frame.autoSwapDesc:SetWidth(500)
     frame.autoSwapDesc:SetTextColor(0.7, 0.7, 0.7)
-    frame.autoSwapDesc:SetText("Automatically swap to fishing gear when showing HUD (right-click minimap), and swap to combat gear when hiding HUD. Requires gear sets to be saved.")
+    frame.autoSwapDesc:SetText("Automatically swap to fishing gear when showing HUD (right-click minimap), and swap to current gear when hiding HUD. Requires fishing gear set to be saved.")
 
     -- HUD Scale Slider
     frame.hudScaleLabel = frame.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -3185,7 +3194,7 @@ function UI:CreateSettingsTab()
     frame.autoSwapCombatDesc:SetJustifyH("LEFT")
     frame.autoSwapCombatDesc:SetWidth(500)
     frame.autoSwapCombatDesc:SetTextColor(0.7, 0.7, 0.7)
-    frame.autoSwapCombatDesc:SetText("When combat starts with fishing pole equipped: if not casting, auto-swaps to combat weapons. If actively casting, a button appears to click to swap. When combat ends, auto-swaps back to fishing pole. Requires combat gear set to be saved.")
+    frame.autoSwapCombatDesc:SetText("When combat starts with fishing pole equipped: if not casting, auto-swaps to your current weapons. If actively casting, a button appears to click to swap. When combat ends, auto-swaps back to fishing pole. Current gear is auto-saved before each fishing swap.")
 
     -- =============================================
     -- ADVANCED SECTION
@@ -3853,7 +3862,7 @@ local whatsNewContent = {
             "When combat ends, auto-swaps back to your fishing pole",
         },
         fixes = {},
-        tip = "TIP: Enable 'Auto-Swap Combat Weapons' in Settings!\nSave your combat gear first with /cfc savecombat, then fish safely knowing you can defend yourself."
+        tip = "TIP: Enable 'Auto-Swap Combat Weapons' in Settings!\nYour current gear is auto-saved before each fishing swap, so you can fish safely knowing you can defend yourself."
     },
     ["1.0.12"] = {
         features = {
@@ -3892,7 +3901,7 @@ local whatsNewContent = {
             "New setting in Settings tab to enable/disable",
         },
         fixes = {},
-        tip = "TIP: Enable 'Auto-Swap Gear on HUD Toggle' in Settings for one-click fishing setup!\nMake sure to save both your fishing and combat gear sets first."
+        tip = "TIP: Enable 'Auto-Swap Gear on HUD Toggle' in Settings for one-click fishing setup!\nMake sure to save your fishing gear set first. Your current gear is auto-saved on swap."
     },
     ["1.0.9"] = {
         features = {
@@ -4026,15 +4035,15 @@ StaticPopupDialogs["CFC_WHATS_NEW"] = {
 }
 
 StaticPopupDialogs["CFC_CLEAR_GEAR_SETS"] = {
-    text = "Are you sure you want to clear ALL gear sets?\n\nThis will delete:\n• Combat gear set\n• Fishing gear set\n\nYou will need to reconfigure your gear sets after this.\n\nThis action CANNOT be undone!",
+    text = "Are you sure you want to clear ALL gear sets?\n\nThis will delete:\n• Current gear set (auto-saved)\n• Fishing gear set\n\nYou will need to reconfigure your gear sets after this.\n\nThis action CANNOT be undone!",
     button1 = "Yes, Clear Gear Sets",
     button2 = "Cancel",
     OnAccept = function()
         if CFC.db and CFC.db.profile and CFC.db.profile.gearSets then
             -- Clear both gear sets
-            CFC.db.profile.gearSets.combat = {}
+            CFC.db.profile.gearSets.current = {}
             CFC.db.profile.gearSets.fishing = {}
-            CFC.db.profile.gearSets.currentMode = "combat"
+            CFC.db.profile.gearSets.currentMode = "current"
 
             CFC:Print("|cff00ff00Classic Fishing Companion:|r All gear sets have been cleared.")
 


### PR DESCRIPTION
…ad of manually saving a combat gear set, the addon now automatically saves whatever gear you're currently wearing right before swapping to fishing gear

Renamed "Combat" gear set to "Current" with auto-save — your equipped gear is now automatically saved before each fishing swap, supporting multiple specs without manual re-saving.

Changes
Auto-save current gear before swapping to fishing gear Only fishing gear set requires manual saving
Data migration from combat → current for existing users /cfc savecombat deprecated with info message
UI: "Current" tab shows auto-saved label, save button hidden; "Fishing" tab unchanged Updated tooltips, settings descriptions, and changelog tips across all 6 files (Core, UI, TBC/UI, HUD, TBC/HUD, Minimap)