### PR TITLE
V1.1.13 - Fix all looted items counting toward fishing totals (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Classic Fishing Companion will be documented in this file
 - Fishing pole cast counts are no longer inflated by the same non-fishing loot
 - Catches are now tracked correctly with fast auto-loot addons, which can skip the `LOOT_OPENED` event entirely
 
+### Changed
+- Updated interface version for the latest game client
+  - Classic Era: 1.15.9
+
 ### Added
 - Right-click any item in the Catch List to purge it from your database, without typing the name
 - **Recalculate Totals** button in Settings recounts your total and per-item catch counts from your catch history. Repairs totals left inflated by this bug. Also available as `/cfc recalc` — your catches are not deleted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Classic Fishing Companion will be documented in this file.
 
+## [1.1.13] - 2026-08-18
+
+### Fixed
+- Fishing totals no longer count loot from other sources. Any item looted while a fishing pole was equipped — mob loot, gathering nodes, or containers opened from your bags (Inscribed Scrollcase, Curious Crate) — was recorded as a catch. Loot is now identified with the client's own `IsFishingLoot()` check instead of being inferred from your equipped gear and recent cast timing ([#19](https://github.com/DigitalPenguin1/ClassicFishingCompanion/issues/19))
+- Fishing pole cast counts are no longer inflated by the same non-fishing loot
+- Catches are now tracked correctly with fast auto-loot addons, which can skip the `LOOT_OPENED` event entirely
+
+### Added
+- Right-click any item in the Catch List to purge it from your database, without typing the name
+- **Recalculate Totals** button in Settings recounts your total and per-item catch counts from your catch history. Repairs totals left inflated by this bug. Also available as `/cfc recalc` — your catches are not deleted
+
+### Note
+- This release stops incorrect catches from accumulating, but does not remove ones already recorded. Right-click any wrong entry in the Catch List to purge it, then use Recalculate Totals. Fishing pole cast counts cannot be repaired automatically, as nothing recorded which casts were miscounted
+
 ## [1.1.12] - 2026-07-15
 
 ### Fixed

--- a/ClassicFishingCompanion.toc
+++ b/ClassicFishingCompanion.toc
@@ -2,7 +2,7 @@
 ## Title: Classic Fishing Companion
 ## Notes: Track your fishing catches, fish per hour, locations, and statistics
 ## Author: Relyk
-## Version: 1.1.12
+## Version: 1.1.13
 ## SavedVariables: ClassicFishingCompanionDB
 ## SavedVariablesPerCharacter: ClassicFishingCompanionCharDB
 

--- a/ClassicFishingCompanion.toc
+++ b/ClassicFishingCompanion.toc
@@ -1,4 +1,4 @@
-## Interface: 11508
+## Interface: 11509
 ## Title: Classic Fishing Companion
 ## Notes: Track your fishing catches, fish per hour, locations, and statistics
 ## Author: Relyk

--- a/ClassicFishingCompanion_TBC.toc
+++ b/ClassicFishingCompanion_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: Classic Fishing Companion (TBC)
 ## Notes: Track your fishing catches, fish per hour, locations, and statistics
 ## Author: Relyk
-## Version: 1.1.12
+## Version: 1.1.13
 ## SavedVariables: ClassicFishingCompanionDB
 ## SavedVariablesPerCharacter: ClassicFishingCompanionCharDB
 ## IconTexture: Interface\AddOns\ClassicFishingCompanion\Textures\icon

--- a/Core.lua
+++ b/Core.lua
@@ -16,7 +16,7 @@ end
 local CFC = CFC
 
 -- Version constant (single source of truth)
-CFC.VERSION = "1.1.12"
+CFC.VERSION = "1.1.13"
 
 -- Centralized color codes for consistent styling
 CFC.COLORS = {
@@ -341,7 +341,9 @@ function CFC:OnEnable()
     self.fishingStartTime = 0
     self.isFishing = false
     self.lastSkillCheck = 0
-    self.lastLootWasFishing = false
+    self.currentLootIsFishing = false  -- True while the open loot window is confirmed fishing loot
+    self.lastFishingLootTime = 0  -- GetTime() when the last fishing loot window closed
+    self.lootWindowMarkedTime = 0  -- GetTime() when the open window was confirmed as fishing
     self.lastBuffWarningTime = 0  -- Track when we last warned about missing buff
     self.currentTrackedBuff = nil  -- Track currently active buff to detect changes
     self.currentBuffExpiration = 0  -- Track buff expiration time to detect reapplications
@@ -373,6 +375,7 @@ function CFC:OnEnable()
     self:RegisterEvent("CHAT_MSG_SKILL", "OnSkillUpdate")
 
     -- Register fishing detection events
+    self:RegisterEvent("LOOT_READY", "OnLootReady")
     self:RegisterEvent("LOOT_OPENED", "OnLootOpened")
     self:RegisterEvent("LOOT_CLOSED", "OnLootClosed")
     self:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START", "OnSpellChannelStart")
@@ -857,75 +860,106 @@ function CFC:ShouldDrinkRumsey()
     return true
 end
 
+-- Grace period for CHAT_MSG_LOOT messages that arrive after LOOT_CLOSED
+local FISHING_LOOT_GRACE = 2.0
+
+-- How long after the fishing channel ends a loot window can still be credited
+-- to fishing. Only used on clients without IsFishingLoot().
+local FISHING_CHANNEL_GRACE = 3.0
+
+-- Safety bound on an open fishing loot window. LOOT_CLOSED clears the flag, but
+-- if a client ever fails to fire it this stops the flag sticking indefinitely
+-- and crediting later loot to fishing.
+local FISHING_LOOT_WINDOW_MAX = 300
+
+-- Ask the client whether the open loot window is fishing loot.
+-- Returns true or false, or nil when the API is unavailable on this client.
+function CFC:QueryFishingLoot()
+    if type(IsFishingLoot) ~= "function" then
+        return nil
+    end
+
+    local ok, result = pcall(IsFishingLoot)
+    if not ok then
+        return nil
+    end
+
+    return result and true or false
+end
+
+-- Heuristic source detection, used only when IsFishingLoot() is unavailable.
+-- Fishing loot always follows the channel ending, so this keys off the channel
+-- stop rather than a wide window from the cast start.
+function CFC:GuessFishingLoot()
+    local mainHandLink = GetInventoryItemLink("player", 16)
+    if not mainHandLink then
+        return false
+    end
+
+    local itemName, _, _, _, _, _, itemSubType = GetItemInfo(mainHandLink)
+    if not itemName or not itemSubType then
+        return false
+    end
+
+    local isFishingPole = string.find(string.lower(itemSubType), "fishing") ~= nil
+    local hasDeadTarget = UnitExists("target") and UnitIsDead("target")
+    local justFinishedChannel = (GetTime() - self.easyCastChannelStopTime) < FISHING_CHANNEL_GRACE
+
+    return isFishingPole and not hasDeadTarget and justFinishedChannel
+end
+
+-- Shared handler for LOOT_READY and LOOT_OPENED.
+-- Either event can confirm fishing loot and a confirmation from one is never
+-- undone by the other, because fast auto-loot means only one may fire.
+function CFC:EvaluateLootWindow(source)
+    if self.currentLootIsFishing then
+        if self.debug then
+            print("|cffff8800[CFC Debug]|r " .. source .. ": already confirmed as fishing loot")
+        end
+        return
+    end
+
+    local native = self:QueryFishingLoot()
+    local isFishingLoot
+    if native ~= nil then
+        isFishingLoot = native
+    else
+        isFishingLoot = self:GuessFishingLoot()
+    end
+
+    if self.debug then
+        print("|cffff8800[CFC Debug]|r " .. source .. ": IsFishingLoot=" .. tostring(native) ..
+            " fishingLoot=" .. tostring(isFishingLoot) ..
+            (native == nil and " (heuristic fallback)" or ""))
+    end
+
+    if not isFishingLoot then
+        -- A new loot window that is definitively not fishing cancels any pending
+        -- grace from the previous window, so loot taken moments after a catch is
+        -- not credited to fishing
+        if native ~= nil then
+            self.lastFishingLootTime = 0
+        end
+        return
+    end
+
+    self.currentLootIsFishing = true
+    self.lootWindowMarkedTime = GetTime()
+    self.isFishing = true
+    self.lastSpellTime = time()
+
+    -- Track the fishing pole cast
+    self:TrackFishingPoleCast()
+end
+
+-- Handle loot becoming available (fires even when auto-loot skips LOOT_OPENED)
+function CFC:OnLootReady()
+    self:EvaluateLootWindow("LOOT_READY")
+end
+
 -- Handle loot window opening
 function CFC:OnLootOpened()
-    -- Check if we have a fishing pole equipped
-    local mainHandLink = GetInventoryItemLink("player", 16)
-
-    if self.debug then
-        print("|cffff8800[CFC Debug]|r OnLootOpened called")
-        print("|cffff8800[CFC Debug]|r  mainHandLink: " .. tostring(mainHandLink))
-    end
-
-    if mainHandLink then
-        local itemName, _, _, _, _, itemType, itemSubType = GetItemInfo(mainHandLink)
-
-        if self.debug then
-            print("|cffff8800[CFC Debug]|r  itemName: " .. tostring(itemName))
-            print("|cffff8800[CFC Debug]|r  itemType: " .. tostring(itemType))
-            print("|cffff8800[CFC Debug]|r  itemSubType: " .. tostring(itemSubType))
-        end
-
-        -- Check if it's actually a fishing pole
-        -- In Classic WoW, fishing poles have itemSubType "Fishing Poles"
-        local isFishingPole = false
-        if itemSubType then
-            local subTypeLower = string.lower(itemSubType)
-            isFishingPole = string.find(subTypeLower, "fishing") ~= nil
-        end
-
-        if self.debug then
-            print("|cffff8800[CFC Debug]|r  isFishingPole: " .. tostring(isFishingPole))
-        end
-
-        -- Check if it's a fishing pole AND not looting a dead mob
-        -- In Classic WoW, when looting a fishing bobber, you typically don't have a dead target
-        -- When looting a mob, UnitIsDead("target") is true
-        local hasDeadTarget = UnitExists("target") and UnitIsDead("target")
-
-        if self.debug then
-            print("|cffff8800[CFC Debug]|r  hasDeadTarget: " .. tostring(hasDeadTarget))
-        end
-
-        local recentlyCastFishing = (GetTime() - self.lastFishingCastTime) < 30
-
-        if itemName and isFishingPole and not hasDeadTarget and recentlyCastFishing then
-            -- We have fishing pole equipped, no dead target, and recently cast Fishing
-            self.lastLootWasFishing = true
-            self.isFishing = true
-            self.lastSpellTime = time()
-
-            -- Track the fishing pole cast
-            self:TrackFishingPoleCast()
-
-            if self.debug then
-                print("|cffff8800[CFC Debug]|r Loot opened from fishing - tracking cast")
-            end
-            return
-        elseif self.debug and itemName and not isFishingPole then
-            print("|cffff8800[CFC Debug]|r Loot opened with non-fishing-pole equipped: " .. itemName)
-        elseif self.debug and itemName and isFishingPole and hasDeadTarget then
-            print("|cffff8800[CFC Debug]|r Loot opened with pole equipped but has dead target (combat loot)")
-        elseif self.debug and itemName and isFishingPole and not recentlyCastFishing then
-            print("|cffff8800[CFC Debug]|r Loot opened with pole equipped but no recent Fishing cast (ground loot?)")
-        end
-    end
-
-    -- Not fishing
-    self.lastLootWasFishing = false
-    if self.debug then
-        print("|cffff8800[CFC Debug]|r Loot opened but NOT fishing")
-    end
+    self:EvaluateLootWindow("LOOT_OPENED")
 end
 
 -- Handle loot window closing
@@ -933,6 +967,13 @@ function CFC:OnLootClosed()
     -- Reset tracked pole so next cast will count
     self.currentTrackedPole = nil
     self.isFishing = false
+
+    -- CHAT_MSG_LOOT can arrive after LOOT_CLOSED, so stamp the close time and let
+    -- OnLootReceived credit messages that land within FISHING_LOOT_GRACE
+    if self.currentLootIsFishing then
+        self.lastFishingLootTime = GetTime()
+    end
+    self.currentLootIsFishing = false
 
     -- Mark loot closed time for Easy Cast (allows quick re-cast)
     self.easyCastLootClosedTime = GetTime()
@@ -1315,32 +1356,22 @@ function CFC:OnLootReceived(event, message)
         return
     end
 
-    -- Check if this loot was obtained while fishing
-    -- Primary: LOOT_OPENED event confirmed this was fishing loot
-    -- Fallback: Check fishing conditions directly (for compatibility with fast auto-loot addons)
-    local wasFishing = self.lastLootWasFishing
+    -- Check whether this loot came from a fishing loot window.
+    -- currentLootIsFishing covers a window that is still open (manual looting),
+    -- lastFishingLootTime covers messages arriving just after LOOT_CLOSED.
+    local sinceFishingLoot = GetTime() - (self.lastFishingLootTime or 0)
+    local windowOpen = self.currentLootIsFishing
+        and (GetTime() - (self.lootWindowMarkedTime or 0)) < FISHING_LOOT_WINDOW_MAX
+    local wasFishing = windowOpen or sinceFishingLoot < FISHING_LOOT_GRACE
 
-    -- Fallback detection if LOOT_OPENED didn't fire (e.g., SpeedyAutoLoot)
-    if not wasFishing then
-        local mainHandLink = GetInventoryItemLink("player", 16)
-        if mainHandLink then
-            local _, _, _, _, _, _, itemSubType = GetItemInfo(mainHandLink)
-            if itemSubType then
-                local isFishingPole = string.find(string.lower(itemSubType), "fishing") ~= nil
-                local hasDeadTarget = UnitExists("target") and UnitIsDead("target")
-                -- Check if player recently cast Fishing (within 30 seconds - bobber lasts ~20-25 sec)
-                local recentlyCastFishing = (GetTime() - self.lastFishingCastTime) < 30
-                if isFishingPole and not hasDeadTarget and recentlyCastFishing then
-                    wasFishing = true
-                    -- Track the fishing pole cast (since OnLootOpened didn't fire)
-                    self:TrackFishingPoleCast()
-                    if self.debug then
-                        print("|cffff8800[CFC Debug]|r Fallback fishing detection: pole equipped, no dead target, recently cast Fishing")
-                    end
-                elseif isFishingPole and not hasDeadTarget and self.debug then
-                    print("|cffff8800[CFC Debug]|r Fallback detection SKIPPED: pole equipped but no recent Fishing cast (mob loot?)")
-                end
-            end
+    -- Last resort for clients without IsFishingLoot(): if no loot window event
+    -- confirmed the source, fall back to channel-timing detection
+    if not wasFishing and self:QueryFishingLoot() == nil and self:GuessFishingLoot() then
+        wasFishing = true
+        -- Track the fishing pole cast (since no loot window event fired)
+        self:TrackFishingPoleCast()
+        if self.debug then
+            print("|cffff8800[CFC Debug]|r Heuristic fallback: credited to fishing (no IsFishingLoot on this client)")
         end
     end
 
@@ -1348,7 +1379,12 @@ function CFC:OnLootReceived(event, message)
     if self.debug then
         print("|cffff8800[CFC Debug]|r Found item: " .. itemName)
         print("|cffff8800[CFC Debug]|r Was fishing: " .. tostring(wasFishing))
-        print("|cffff8800[CFC Debug]|r lastLootWasFishing: " .. tostring(self.lastLootWasFishing))
+        print("|cffff8800[CFC Debug]|r currentLootIsFishing: " .. tostring(self.currentLootIsFishing))
+        if (self.lastFishingLootTime or 0) == 0 then
+            print("|cffff8800[CFC Debug]|r Since fishing loot closed: n/a (no pending fishing loot)")
+        else
+            print(string.format("|cffff8800[CFC Debug]|r Since fishing loot closed: %.2fs (grace %.1fs)", sinceFishingLoot, FISHING_LOOT_GRACE))
+        end
     end
 
     if wasFishing then
@@ -2780,6 +2816,69 @@ function CFC:PurgeItem(itemName)
     end
 end
 
+-- Recalculate stored totals from the catch history.
+-- The catches array is the source of truth: it is only ever appended to,
+-- filtered by PurgeItem, or cleared wholesale, so counts derived from it are
+-- authoritative. Repairs totals that drifted from miscounted catches.
+function CFC:RecalculateTotals()
+    if not self.db or not self.db.profile then
+        return false
+    end
+
+    local catches = self.db.profile.catches or {}
+    local stats = self.db.profile.statistics
+
+    -- Recount total catches
+    local oldTotal = stats.totalCatches or 0
+    local newTotal = #catches
+    stats.totalCatches = newTotal
+
+    -- Recount per-item totals from the same source
+    local tally = {}
+    for _, catch in ipairs(catches) do
+        if catch.itemName then
+            tally[catch.itemName] = (tally[catch.itemName] or 0) + 1
+        end
+    end
+
+    local itemsFixed, orphaned = 0, 0
+    for itemName, data in pairs(self.db.profile.fishData or {}) do
+        local counted = tally[itemName] or 0
+        if data.count ~= counted then
+            data.count = counted
+            itemsFixed = itemsFixed + 1
+        end
+        if counted == 0 then
+            orphaned = orphaned + 1
+        end
+    end
+
+    -- Update UI if open
+    if self.UpdateUI then
+        self:UpdateUI()
+    end
+
+    -- Update HUD
+    if self.HUD and self.HUD.Update then
+        self.HUD:Update()
+    end
+
+    if oldTotal == newTotal and itemsFixed == 0 then
+        CFC:Print("|cff00ff00Classic Fishing Companion:|r Totals already match catch history (" .. newTotal .. " catches). Nothing to fix.")
+    else
+        CFC:Print("|cff00ff00Classic Fishing Companion:|r Totals recalculated: " ..
+            oldTotal .. " -> " .. newTotal .. " catches" ..
+            (itemsFixed > 0 and (", " .. itemsFixed .. " item count(s) corrected") or ""))
+    end
+
+    if orphaned > 0 then
+        CFC:Print("|cffffcc00Classic Fishing Companion:|r " .. orphaned ..
+            " item(s) have no remaining catches. Use Purge Item to remove them from your lists.")
+    end
+
+    return true
+end
+
 -- Import fishing data from a string
 function CFC:ImportData(importString)
     if not importString or importString == "" then
@@ -2988,6 +3087,8 @@ SlashCmdList["CFC"] = function(msg)
             CFC.db.profile.statistics.sessionCatches = 0
             CFC:Print("|cff00ff00Classic Fishing Companion:|r All data has been reset.")
         end
+    elseif msg == "recalc" or msg == "recalculate" then
+        CFC:RecalculateTotals()
     elseif msg == "stats" then
         CFC:PrintStats()
     elseif msg == "debug" then

--- a/TBC/UI.lua
+++ b/TBC/UI.lua
@@ -3856,6 +3856,7 @@ local whatsNewContent = {
         fixes = {
             "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
             "Fishing pole cast counts are no longer inflated by non-fishing loot",
+            "Updated for Classic Era 1.15.9",
         },
         features = {
             "Right-click any item in the Catch List to remove it from your database",

--- a/TBC/UI.lua
+++ b/TBC/UI.lua
@@ -662,6 +662,8 @@ function UI:UpdateFishList()
                     end
                 end
 
+                GameTooltip:AddLine(" ")
+                GameTooltip:AddLine("|cffff8080Right-click to purge this item|r")
                 GameTooltip:Show()
             end)
 
@@ -674,6 +676,15 @@ function UI:UpdateFishList()
 
         entry:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", 10, yOffset)
         entry.fishName = fish.name
+
+        -- Right-click purges this item. The user decides what is junk; the addon
+        -- never guesses, because nothing records whether an entry came from a
+        -- bobber or a corpse.
+        entry:SetScript("OnMouseUp", function(self, button)
+            if button == "RightButton" and self.fishName and CFC.UI and CFC.UI.ShowPurgeDialog then
+                CFC.UI:ShowPurgeDialog(self.fishName)
+            end
+        end)
 
         -- Try to get icon from cached data first (saved when fish was caught)
         local itemTexture = nil
@@ -943,6 +954,8 @@ function UI:UpdateFishList()
                     end
                 end
 
+                GameTooltip:AddLine(" ")
+                GameTooltip:AddLine("|cffff8080Right-click to purge this item|r")
                 GameTooltip:Show()
             end)
 
@@ -955,6 +968,15 @@ function UI:UpdateFishList()
 
         entry:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", 10, yOffset)
         entry.fishName = misc.name
+
+        -- Right-click purges this item. The user decides what is junk; the addon
+        -- never guesses, because nothing records whether an entry came from a
+        -- bobber or a corpse.
+        entry:SetScript("OnMouseUp", function(self, button)
+            if button == "RightButton" and self.fishName and CFC.UI and CFC.UI.ShowPurgeDialog then
+                CFC.UI:ShowPurgeDialog(self.fishName)
+            end
+        end)
 
         -- Try to get icon from cached data first (saved when item was caught)
         local itemTexture = nil
@@ -3414,10 +3436,28 @@ function UI:CreateSettingsTab()
     frame.purgeDesc:SetTextColor(0.7, 0.7, 0.7)
     frame.purgeDesc:SetText("Remove a specific item from your catches and statistics by name.")
 
+    -- Recalculate Totals Button
+    frame.recalcButton = CreateFrame("Button", "CFCRecalcButton", frame.scrollChild, "UIPanelButtonTemplate")
+    frame.recalcButton:SetSize(200, 30)
+    frame.recalcButton:SetPoint("TOPLEFT", frame.purgeDesc, "BOTTOMLEFT", -25, -20)
+    frame.recalcButton:SetText("Recalculate Totals")
+
+    frame.recalcButton:SetScript("OnClick", function(self)
+        StaticPopup_Show("CFC_RECALC_CONFIRM")
+    end)
+
+    -- Recalculate description
+    frame.recalcDesc = frame.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    frame.recalcDesc:SetPoint("TOPLEFT", frame.recalcButton, "BOTTOMLEFT", 25, -5)
+    frame.recalcDesc:SetJustifyH("LEFT")
+    frame.recalcDesc:SetWidth(500)
+    frame.recalcDesc:SetTextColor(0.7, 0.7, 0.7)
+    frame.recalcDesc:SetText("Recount your totals from your catch history. Fixes totals left inflated by miscounted catches. Your catches are not deleted.")
+
     -- Clear Statistics Button
     frame.clearStatsButton = CreateFrame("Button", "CFCClearStatsButton", frame.scrollChild, "UIPanelButtonTemplate")
     frame.clearStatsButton:SetSize(200, 30)
-    frame.clearStatsButton:SetPoint("TOPLEFT", frame.purgeDesc, "BOTTOMLEFT", -25, -20)
+    frame.clearStatsButton:SetPoint("TOPLEFT", frame.recalcDesc, "BOTTOMLEFT", -25, -20)
     frame.clearStatsButton:SetText("Clear All Statistics")
 
     frame.clearStatsButton:SetScript("OnClick", function(self)
@@ -3661,6 +3701,23 @@ StaticPopupDialogs["CFC_RESTORE_BACKUP_CONFIRM"] = {
     preferredIndex = 3,
 }
 
+
+-- Recalculate totals confirmation dialog
+StaticPopupDialogs["CFC_RECALC_CONFIRM"] = {
+    text = "Recalculate totals from your catch history?\n\nYour catches are not deleted. Your total catch count is recounted from them, which may lower the number if miscounted catches were removed.",
+    button1 = "Yes, Recalculate",
+    button2 = "Cancel",
+    OnAccept = function()
+        if CFC.RecalculateTotals then
+            CFC:RecalculateTotals()
+        end
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
 -- Per-character mode ENABLE dialog (with copy option)
 StaticPopupDialogs["CFC_PERCHAR_ENABLE"] = {
     text = "Enable Per-Character Statistics?\n\n|cffffcc00Choose how to start:|r\n\n|cff00ff00Copy Account Data:|r\nThis character will start with all your current catches (%d total).\n\n|cffaaaaaa[Cancel] Start Fresh:|r\nThis character will start with 0 catches.\n\n|cff888888Your account-wide data remains safe either way.|r",
@@ -3795,6 +3852,17 @@ StaticPopupDialogs["CFC_ABOUT_DIALOG"] = {
 
 -- Version-specific What's New content
 local whatsNewContent = {
+    ["1.1.13"] = {
+        fixes = {
+            "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
+            "Fishing pole cast counts are no longer inflated by non-fishing loot",
+        },
+        features = {
+            "Right-click any item in the Catch List to remove it from your database",
+            "New Recalculate Totals button in Settings recounts your totals from your catch history",
+        },
+        tip = "TIP: Tight lines and happy fishing!\n- Relyk"
+    },
     ["1.1.12"] = {
         fixes = {
             "Sharpened Fish Hook now shows by name on the HUD (follows your selected lure) instead of always displaying as Aquadynamic Fish Attractor",
@@ -4321,7 +4389,7 @@ function UI:ShowImportDialog()
 end
 
 -- Create and show purge item dialog
-function UI:ShowPurgeDialog()
+function UI:ShowPurgeDialog(prefillName)
     -- Create simple input dialog
     local dialog = CreateFrame("Frame", "CFCPurgeDialog", UIParent, "BasicFrameTemplateWithInset")
     dialog:SetSize(400, 150)
@@ -4351,6 +4419,12 @@ function UI:ShowPurgeDialog()
     dialog.inputBox:SetPoint("TOP", dialog.instructions, "BOTTOM", 0, -10)
     dialog.inputBox:SetAutoFocus(true)
     dialog.inputBox:SetMaxLetters(100)
+
+    -- Pre-fill when opened from a Catch List row
+    if prefillName then
+        dialog.inputBox:SetText(prefillName)
+        dialog.inputBox:HighlightText()
+    end
 
     dialog.inputBox:SetScript("OnEscapePressed", function(self)
         dialog:Hide()

--- a/TBC/UI.lua
+++ b/TBC/UI.lua
@@ -3856,6 +3856,8 @@ local whatsNewContent = {
         fixes = {
             "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
             "Fishing pole cast counts are no longer inflated by non-fishing loot",
+        },
+        changes = {
             "Updated for Classic Era 1.15.9",
         },
         features = {
@@ -4178,6 +4180,15 @@ local function GetWhatsNewText(version)
         text = text .. "|cffffcc00New Features:|r\n"
         for _, feature in ipairs(content.features) do
             text = text .. "• " .. feature .. "\n"
+        end
+        text = text .. "\n"
+    end
+
+    -- Add changes
+    if content.changes and #content.changes > 0 then
+        text = text .. "|cffffcc00Updates:|r\n"
+        for _, change in ipairs(content.changes) do
+            text = text .. "• " .. change .. "\n"
         end
         text = text .. "\n"
     end

--- a/UI.lua
+++ b/UI.lua
@@ -3782,6 +3782,7 @@ local whatsNewContent = {
         fixes = {
             "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
             "Fishing pole cast counts are no longer inflated by non-fishing loot",
+            "Updated for Classic Era 1.15.9",
         },
         features = {
             "Right-click any item in the Catch List to remove it from your database",

--- a/UI.lua
+++ b/UI.lua
@@ -662,6 +662,8 @@ function UI:UpdateFishList()
                     end
                 end
 
+                GameTooltip:AddLine(" ")
+                GameTooltip:AddLine("|cffff8080Right-click to purge this item|r")
                 GameTooltip:Show()
             end)
 
@@ -674,6 +676,15 @@ function UI:UpdateFishList()
 
         entry:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", 10, yOffset)
         entry.fishName = fish.name
+
+        -- Right-click purges this item. The user decides what is junk; the addon
+        -- never guesses, because nothing records whether an entry came from a
+        -- bobber or a corpse.
+        entry:SetScript("OnMouseUp", function(self, button)
+            if button == "RightButton" and self.fishName and CFC.UI and CFC.UI.ShowPurgeDialog then
+                CFC.UI:ShowPurgeDialog(self.fishName)
+            end
+        end)
 
         -- Try to get icon from cached data first (saved when fish was caught)
         local itemTexture = nil
@@ -943,6 +954,8 @@ function UI:UpdateFishList()
                     end
                 end
 
+                GameTooltip:AddLine(" ")
+                GameTooltip:AddLine("|cffff8080Right-click to purge this item|r")
                 GameTooltip:Show()
             end)
 
@@ -955,6 +968,15 @@ function UI:UpdateFishList()
 
         entry:SetPoint("TOPLEFT", frame.scrollChild, "TOPLEFT", 10, yOffset)
         entry.fishName = misc.name
+
+        -- Right-click purges this item. The user decides what is junk; the addon
+        -- never guesses, because nothing records whether an entry came from a
+        -- bobber or a corpse.
+        entry:SetScript("OnMouseUp", function(self, button)
+            if button == "RightButton" and self.fishName and CFC.UI and CFC.UI.ShowPurgeDialog then
+                CFC.UI:ShowPurgeDialog(self.fishName)
+            end
+        end)
 
         -- Try to get icon from cached data first (saved when item was caught)
         local itemTexture = nil
@@ -3344,10 +3366,28 @@ function UI:CreateSettingsTab()
     frame.purgeDesc:SetTextColor(0.7, 0.7, 0.7)
     frame.purgeDesc:SetText("Remove a specific item from your catches and statistics by name.")
 
+    -- Recalculate Totals Button
+    frame.recalcButton = CreateFrame("Button", "CFCRecalcButton", frame.scrollChild, "UIPanelButtonTemplate")
+    frame.recalcButton:SetSize(200, 30)
+    frame.recalcButton:SetPoint("TOPLEFT", frame.purgeDesc, "BOTTOMLEFT", -25, -20)
+    frame.recalcButton:SetText("Recalculate Totals")
+
+    frame.recalcButton:SetScript("OnClick", function(self)
+        StaticPopup_Show("CFC_RECALC_CONFIRM")
+    end)
+
+    -- Recalculate description
+    frame.recalcDesc = frame.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    frame.recalcDesc:SetPoint("TOPLEFT", frame.recalcButton, "BOTTOMLEFT", 25, -5)
+    frame.recalcDesc:SetJustifyH("LEFT")
+    frame.recalcDesc:SetWidth(500)
+    frame.recalcDesc:SetTextColor(0.7, 0.7, 0.7)
+    frame.recalcDesc:SetText("Recount your totals from your catch history. Fixes totals left inflated by miscounted catches. Your catches are not deleted.")
+
     -- Clear Statistics Button
     frame.clearStatsButton = CreateFrame("Button", "CFCClearStatsButton", frame.scrollChild, "UIPanelButtonTemplate")
     frame.clearStatsButton:SetSize(200, 30)
-    frame.clearStatsButton:SetPoint("TOPLEFT", frame.purgeDesc, "BOTTOMLEFT", -25, -20)
+    frame.clearStatsButton:SetPoint("TOPLEFT", frame.recalcDesc, "BOTTOMLEFT", -25, -20)
     frame.clearStatsButton:SetText("Clear All Statistics")
 
     frame.clearStatsButton:SetScript("OnClick", function(self)
@@ -3591,6 +3631,23 @@ StaticPopupDialogs["CFC_RESTORE_BACKUP_CONFIRM"] = {
     preferredIndex = 3,
 }
 
+
+-- Recalculate totals confirmation dialog
+StaticPopupDialogs["CFC_RECALC_CONFIRM"] = {
+    text = "Recalculate totals from your catch history?\n\nYour catches are not deleted. Your total catch count is recounted from them, which may lower the number if miscounted catches were removed.",
+    button1 = "Yes, Recalculate",
+    button2 = "Cancel",
+    OnAccept = function()
+        if CFC.RecalculateTotals then
+            CFC:RecalculateTotals()
+        end
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
 -- Per-character mode ENABLE dialog (with copy option)
 StaticPopupDialogs["CFC_PERCHAR_ENABLE"] = {
     text = "Enable Per-Character Statistics?\n\n|cffffcc00Choose how to start:|r\n\n|cff00ff00Copy Account Data:|r\nThis character will start with all your current catches (%d total).\n\n|cffaaaaaa[Cancel] Start Fresh:|r\nThis character will start with 0 catches.\n\n|cff888888Your account-wide data remains safe either way.|r",
@@ -3721,6 +3778,17 @@ StaticPopupDialogs["CFC_ABOUT_DIALOG"] = {
 
 -- Version-specific What's New content
 local whatsNewContent = {
+    ["1.1.13"] = {
+        fixes = {
+            "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
+            "Fishing pole cast counts are no longer inflated by non-fishing loot",
+        },
+        features = {
+            "Right-click any item in the Catch List to remove it from your database",
+            "New Recalculate Totals button in Settings recounts your totals from your catch history",
+        },
+        tip = "TIP: Tight lines and happy fishing!\n- Relyk"
+    },
     ["1.1.12"] = {
         fixes = {
             "HUD no longer spills past its border - it grows taller when a long lure name wraps to a second line, keeping the lure timer inside the frame",
@@ -4246,7 +4314,7 @@ function UI:ShowImportDialog()
 end
 
 -- Create and show purge item dialog
-function UI:ShowPurgeDialog()
+function UI:ShowPurgeDialog(prefillName)
     -- Create simple input dialog
     local dialog = CreateFrame("Frame", "CFCPurgeDialog", UIParent, "BasicFrameTemplateWithInset")
     dialog:SetSize(400, 150)
@@ -4276,6 +4344,12 @@ function UI:ShowPurgeDialog()
     dialog.inputBox:SetPoint("TOP", dialog.instructions, "BOTTOM", 0, -10)
     dialog.inputBox:SetAutoFocus(true)
     dialog.inputBox:SetMaxLetters(100)
+
+    -- Pre-fill when opened from a Catch List row
+    if prefillName then
+        dialog.inputBox:SetText(prefillName)
+        dialog.inputBox:HighlightText()
+    end
 
     dialog.inputBox:SetScript("OnEscapePressed", function(self)
         dialog:Hide()

--- a/UI.lua
+++ b/UI.lua
@@ -3782,6 +3782,8 @@ local whatsNewContent = {
         fixes = {
             "Fishing totals no longer count loot from other sources - mob loot, gathering, and items opened from your bags are no longer recorded as catches",
             "Fishing pole cast counts are no longer inflated by non-fishing loot",
+        },
+        changes = {
             "Updated for Classic Era 1.15.9",
         },
         features = {
@@ -4103,6 +4105,15 @@ local function GetWhatsNewText(version)
         text = text .. "|cffffcc00New Features:|r\n"
         for _, feature in ipairs(content.features) do
             text = text .. "• " .. feature .. "\n"
+        end
+        text = text .. "\n"
+    end
+
+    -- Add changes
+    if content.changes and #content.changes > 0 then
+        text = text .. "|cffffcc00Updates:|r\n"
+        for _, change in ipairs(content.changes) do
+            text = text .. "• " .. change .. "\n"
         end
         text = text .. "\n"
     end

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -6,6 +6,13 @@ For the full detailed changelog, see [CHANGELOG.md](https://github.com/DigitalPe
 
 ## Recent Versions
 
+### v1.1.13
+- Fishing totals no longer count loot from other sources — mob loot, gathering, and containers opened from your bags are no longer recorded as catches ([#19](https://github.com/DigitalPenguin1/ClassicFishingCompanion/issues/19))
+- Fishing pole cast counts are no longer inflated by non-fishing loot
+- Catches now track correctly with fast auto-loot addons
+- Right-click any item in the Catch List to purge it from your database
+- New **Recalculate Totals** button in Settings (`/cfc recalc`) recounts your totals from your catch history
+
 ### v1.1.12
 - **TBC** - Sharpened Fish Hook now shows by name on the HUD (named from your selected lure) instead of always as Aquadynamic Fish Attractor — both share the same +100 weapon enchant and an identical pole tooltip
 - HUD grows taller when a long lure name wraps to a second line, so the lure timer no longer falls outside the frame

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -12,6 +12,7 @@ For the full detailed changelog, see [CHANGELOG.md](https://github.com/DigitalPe
 - Catches now track correctly with fast auto-loot addons
 - Right-click any item in the Catch List to purge it from your database
 - New **Recalculate Totals** button in Settings (`/cfc recalc`) recounts your totals from your catch history
+- Updated for Classic Era 1.15.9
 
 ### v1.1.12
 - **TBC** - Sharpened Fish Hook now shows by name on the HUD (named from your selected lure) instead of always as Aquadynamic Fish Attractor — both share the same +100 weapon enchant and an identical pole tooltip

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -31,6 +31,7 @@ All CFC slash commands start with `/cfc`.
 | Command | Description |
 |---|---|
 | `/cfc reset` | Reset all saved data (prompts for confirmation) |
+| `/cfc recalc` | Recount totals from your catch history (does not delete catches) |
 
 ---
 


### PR DESCRIPTION
Closes #19

Any item looted with a fishing pole equipped was recorded as a catch — mob loot, gathering, and containers opened from bags.

## Root cause

Two separate defects, both visible in the reporter's debug log.

`lastLootWasFishing` was set when a loot window was confirmed as fishing, but the only place it was ever cleared was inside `OnLootOpened` itself. Clients using fast auto-loot never fire `LOOT_OPENED`, so the flag stayed true and every later `CHAT_MSG_LOOT` was credited to fishing.

The source check was also a heuristic — pole equipped, no dead target, cast within 30s — which a bag container satisfies. Opening an Inscribed Scrollcase recorded its contents *and* incremented the pole cast total.

## Fix

Loot source now comes from the client's own `IsFishingLoot()`, evaluated on both `LOOT_READY` and `LOOT_OPENED` since only one may fire depending on auto-loot. The old heuristic is kept solely as a fallback for clients lacking the API, re-keyed off the channel stop instead of a 30s window from cast start.

`CHAT_MSG_LOOT` arrives *after* `LOOT_CLOSED`, so attribution uses a 2s grace after the window closes. A non-fishing window cancels that grace, and an open window is time-bounded so a missed `LOOT_CLOSED` can't make it stick.

## Verification

Verified in-game on TBC 2.5.6 across several rounds:

- Fishing records normally; pole counts step once per cast even when `LOOT_READY`, `LOOT_OPENED`, and a second `LOOT_READY` all fire for one window
- Mob loot is refused, including 1.9s after a catch — inside the old grace window
- Opening an Inscribed Scrollcase from bags is refused, and no longer inflates the pole count
- A fished-up Scrollcase is still correctly counted as a catch

`IsFishingLoot()` was confirmed valid during `LOOT_READY` on this client, and `LOOT_OPENED` was confirmed *not* to fire for fishing loot there — which is why both events are handled.

## Cleanup

Existing miscounted entries are not removed automatically. Nothing in the saved data records whether an entry came from a bobber or a corpse, and items like Grime-encrusted Scale are plausible from both, so a classifier would delete real catches.

- Right-click any Catch List item to purge it, no typing needed
- **Recalculate Totals** in Settings (`/cfc recalc`) recounts totals from catch history without deleting anything

Pole cast counts can't be repaired — nothing recorded which casts were miscounted.

## Also included

Classic Era interface bumped to 1.15.9 (`11509`) in its own commit; TBC stays 2.5.6 (`20506`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)